### PR TITLE
docs: point help link to nself.org

### DIFF
--- a/bin/nself.sh
+++ b/bin/nself.sh
@@ -829,7 +829,7 @@ $(echo_info "Optional Services:")
   • GoLang:          High-performance services
   • Python:          ML/AI and data analysis
 
-$(echo_info "Documentation:") https://nself.com
+$(echo_info "Documentation:") https://nself.org
 $(echo_info "GitHub:") https://github.com/acamarata/nself
 
 EOF


### PR DESCRIPTION
## Summary
- replace documentation URL in CLI help from nself.com to nself.org

## Testing
- `bin/nself.sh help`
- `shellcheck bin/nself.sh`

------
https://chatgpt.com/codex/tasks/task_e_6895413f49088327bf8802fbd35b4d2e