### PR TITLE
fix: detect docker compose plugin

### DIFF
--- a/bin/nself.sh
+++ b/bin/nself.sh
@@ -863,7 +863,7 @@ if ! command_exists docker; then
   exit 1
 fi
 
-if ! command_exists docker compose && ! command_exists docker-compose; then
+if ! docker compose version >/dev/null 2>&1 && ! command_exists docker-compose; then
   echo_error "Docker Compose is not installed. Please install Docker Compose first."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- fix docker compose dependency check to correctly detect the Docker Compose plugin

## Testing
- `bash -n bin/nself.sh`


------
https://chatgpt.com/codex/tasks/task_e_68954168f60883279c4a0dbe432a655b