### PR TITLE
fix: keep camelCase first character lowercase

### DIFF
--- a/bin/services.sh
+++ b/bin/services.sh
@@ -21,7 +21,7 @@ mkdir -p services
 
 # Helper function to convert kebab-case to camelCase
 to_camel_case() {
-  echo "$1" | sed -r 's/(^|-)([a-z])/\U\2/g'
+  echo "$1" | sed -r 's/-([a-z])/\U\1/g'
 }
 
 # Helper function to convert kebab-case to PascalCase


### PR DESCRIPTION
## Summary
- ensure `to_camel_case` preserves the lowercase first character

## Testing
- `shellcheck bin/services.sh`
- `bash -n bin/services.sh`


------
https://chatgpt.com/codex/tasks/task_e_68954176dea88327974f28cf9f5f4e2d