### PR TITLE
Add tests for service naming helpers

### DIFF
--- a/tests/services_functions.bats
+++ b/tests/services_functions.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+@test "to_camel_case converts hyphenated name to camelCase" {
+  run bash -c "source <(sed -n '23,30p' bin/services.sh); to_camel_case 'my-service'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "myService" ]
+}
+
+@test "to_pascal_case converts hyphenated name to PascalCase" {
+  run bash -c "source <(sed -n '23,30p' bin/services.sh); to_pascal_case 'my-service'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "MyService" ]
+}


### PR DESCRIPTION
## Summary
- add Bats tests covering to_camel_case and to_pascal_case conversions
- execute functions in isolated shell to avoid side effects

## Testing
- `bats tests/services_functions.bats` *(fails: to_camel_case converts hyphenated name to camelCase)*

------
https://chatgpt.com/codex/tasks/task_e_6895417ca630832790751345a29183bb