### PR TITLE
fix: clean up nself.sh dependency check

### DIFF
--- a/bin/nself.sh
+++ b/bin/nself.sh
@@ -857,20 +857,6 @@ case "$1" in
     ;;
 esac
 
-#<<<<<<< codex/locate-and-fix-bugs
-=======
-# Check dependencies
-if ! command_exists docker; then
-  echo_error "Docker is not installed. Please install Docker first."
-  exit 1
-fi
-
-if ! docker compose version >/dev/null 2>&1 && ! command_exists docker-compose; then
-  echo_error "Docker Compose is not installed. Please install Docker Compose first."
-  exit 1
-fi
-
-#>>>>>>> main
 # Process commands
 COMMAND="$1"
 
@@ -881,7 +867,7 @@ if [ "$COMMAND" != "update" ]; then
     exit 1
   fi
 
-  if ! command_exists docker compose && ! command_exists docker-compose; then
+  if ! docker compose version >/dev/null 2>&1 && ! command_exists docker-compose; then
     echo_error "Docker Compose is not installed. Please install Docker Compose first."
     exit 1
   fi


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers in nself.sh
- ensure docker compose dependency check uses proper detection and only runs when not updating

## Testing
- `bats tests/services_functions.bats`


------
https://chatgpt.com/codex/tasks/task_e_68954f2d53b08327b01d12d55e09917e