### PR TITLE
feat: show service URLs after build and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,16 @@ nself init
 
 # 3. Build and launch everything
 nself build && nself up
+# URLs for enabled services will be shown in the output
 ```
 
 **That's it!** Your complete backend is now running at:
 - 🚀 GraphQL API: https://api.local.nself.org
-- 🔐 Auth Service: https://auth.local.nself.org  
+- 🔐 Auth Service: https://auth.local.nself.org
 - 📦 Storage: https://storage.local.nself.org
 - 📊 And more...
+
+*Tip:* These URLs are also printed after `nself build` and `nself up` so they're easy to copy.
 
 ### Want to customize?
 

--- a/bin/nself.sh
+++ b/bin/nself.sh
@@ -290,6 +290,9 @@ cmd_build() {
     fi
     echo ""
     echo_info "  Next: Run 'nself up' to start services"
+    echo ""
+    # Show configured service URLs
+    bash "$SCRIPT_DIR/urls.sh"
   else
     echo_error "Build failed. Check /tmp/nself_build.log for details."
     exit 1

--- a/bin/success.sh
+++ b/bin/success.sh
@@ -4,14 +4,16 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Load environment
-if [ -f ".env.local" ]; then
+if [ -f "$SCRIPT_DIR/../.env.local" ]; then
   set -o allexport
-  source .env.local
+  source "$SCRIPT_DIR/../.env.local"
   set +o allexport
-elif [ -f ".env" ]; then
+elif [ -f "$SCRIPT_DIR/../.env" ]; then
   set -o allexport
-  source .env
+  source "$SCRIPT_DIR/../.env"
   set +o allexport
 fi
 
@@ -20,6 +22,7 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
+RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 echo
@@ -27,56 +30,10 @@ echo -e "${GREEN}✨ nself services started successfully!${NC}"
 echo
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo
-echo -e "${CYAN}🌐 Service URLs:${NC}"
+# Show service URLs
+bash "$SCRIPT_DIR/urls.sh"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo
-
-# Determine protocol
-if [[ "$SSL_MODE" == "local" ]] || [[ "$SSL_MODE" == "letsencrypt" ]] || [[ -n "$SSL_CERT_PATH" ]]; then
-  PROTOCOL="https"
-else
-  PROTOCOL="http"
-fi
-
-# Core services
-echo -e "${YELLOW}GraphQL API:${NC}"
-echo -e "  ${PROTOCOL}://${HASURA_ROUTE}"
-echo -e "  Admin Secret: ${HASURA_GRAPHQL_ADMIN_SECRET}"
-echo
-
-echo -e "${YELLOW}Authentication:${NC}"
-echo -e "  ${PROTOCOL}://${AUTH_ROUTE}"
-echo
-
-echo -e "${YELLOW}Storage API:${NC}"
-echo -e "  ${PROTOCOL}://${STORAGE_ROUTE}"
-echo -e "  Console: ${PROTOCOL}://${STORAGE_CONSOLE_ROUTE}"
-echo -e "  Access Key: ${MINIO_ROOT_USER}"
-echo
-
-# Optional services
-if [[ "$FUNCTIONS_ENABLED" == "true" ]]; then
-  echo -e "${YELLOW}Functions:${NC}"
-  echo -e "  ${PROTOCOL}://${FUNCTIONS_ROUTE}"
-  echo
-fi
-
-if [[ "$DASHBOARD_ENABLED" == "true" ]]; then
-  echo -e "${YELLOW}Dashboard:${NC}"
-  echo -e "  ${PROTOCOL}://${DASHBOARD_ROUTE}"
-  echo
-fi
-
-if [[ "$EMAIL_PROVIDER" == "mailhog" ]]; then
-  echo -e "${YELLOW}Email Testing (MailHog):${NC}"
-  echo -e "  ${PROTOCOL}://${MAILHOG_ROUTE}"
-  echo
-fi
-
-if [[ "$NESTJS_ENABLED" == "true" ]]; then
-  echo -e "${YELLOW}Microservice:${NC}"
-  echo -e "  ${PROTOCOL}://${NESTJS_ROUTE}"
-  echo
-fi
 
 # Database connection
 echo -e "${YELLOW}Database:${NC}"
@@ -93,9 +50,6 @@ if [[ "$REDIS_ENABLED" == "true" ]]; then
   echo -e "  Port: ${REDIS_PORT}"
   echo
 fi
-
-echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo
 
 # Quick commands
 echo -e "${CYAN}📝 Quick Commands:${NC}"

--- a/bin/urls.sh
+++ b/bin/urls.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# urls.sh - Display service URLs for nself stack
+
+# Determine root directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load environment if not already loaded
+if [ -z "$HASURA_ROUTE" ]; then
+  if [ -f "$ROOT_DIR/.env.local" ]; then
+    set -o allexport
+    source "$ROOT_DIR/.env.local"
+    set +o allexport
+  elif [ -f "$ROOT_DIR/.env" ]; then
+    set -o allexport
+    source "$ROOT_DIR/.env"
+    set +o allexport
+  fi
+fi
+
+# Colors
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Determine protocol
+if [[ "$SSL_MODE" == "local" ]] || [[ "$SSL_MODE" == "letsencrypt" ]] || [[ -n "$SSL_CERT_PATH" ]]; then
+  PROTOCOL="https"
+else
+  PROTOCOL="http"
+fi
+
+echo -e "${BLUE}🌐 Service URLs:${NC}"
+echo
+
+echo -e "  ${YELLOW}GraphQL API:${NC} ${PROTOCOL}://${HASURA_ROUTE}"
+echo -e "      Admin Secret: ${HASURA_GRAPHQL_ADMIN_SECRET}"
+echo
+
+echo -e "  ${YELLOW}Authentication:${NC} ${PROTOCOL}://${AUTH_ROUTE}"
+echo
+
+echo -e "  ${YELLOW}Storage API:${NC} ${PROTOCOL}://${STORAGE_ROUTE}"
+echo -e "      Console: ${PROTOCOL}://${STORAGE_CONSOLE_ROUTE}"
+echo -e "      Access Key: ${MINIO_ROOT_USER}"
+echo
+
+if [[ "$FUNCTIONS_ENABLED" == "true" ]]; then
+  echo -e "  ${YELLOW}Functions:${NC} ${PROTOCOL}://${FUNCTIONS_ROUTE}"
+  echo
+fi
+
+if [[ "$DASHBOARD_ENABLED" == "true" ]]; then
+  echo -e "  ${YELLOW}Dashboard:${NC} ${PROTOCOL}://${DASHBOARD_ROUTE}"
+  echo
+fi
+
+if [[ "$EMAIL_PROVIDER" == "mailhog" ]]; then
+  echo -e "  ${YELLOW}MailHog:${NC} ${PROTOCOL}://${MAILHOG_ROUTE}"
+  echo
+fi


### PR DESCRIPTION
## Summary
- show configured service URLs after `nself build`
- centralize URL printing in new helper script
- mention automatic URL output in README

## Testing
- `bats tests/services_functions.bats`


------
https://chatgpt.com/codex/tasks/task_e_689550ff0d908327ba124a7c676c6722